### PR TITLE
Updated Horus template to support Horus 0.4+ and the Horus Plugin Repository

### DIFF
--- a/utils_biobb/horus/templates/horus_meta.meta
+++ b/utils_biobb/horus/templates/horus_meta.meta
@@ -1,4 +1,5 @@
 {
+    "id": "{{_id}}",
     "name": "{{_id}}",
     "description": "The Horus adapter for {{_id}}",
     "author": "Pau Andrio",

--- a/utils_biobb/horus/templates/horus_plugin.jpy
+++ b/utils_biobb/horus/templates/horus_plugin.jpy
@@ -3,7 +3,7 @@ from HorusAPI import Plugin, PluginConfig, PluginVariable, VariableTypes
 {% for module_name, dot_path in dot_paths_dict.items() %}
 from {{dot_path}} import {{module_name}}_block
 {% endfor %}
-plugin = Plugin(id='{{block_name}}')
+plugin = Plugin()
 {% for module_name, dot_path in dot_paths_dict.items() %}
 plugin.addBlock({{module_name}}_block)
 {% endfor %}


### PR DESCRIPTION
- Horus 0.4+ requires the ID of the plugin to be defined in the plugin.meta file. 
- This is necessary also for uploading plugins to the Horus Plugin Repository: [horus.bsc.es/repo](horus.bsc.es/repo)